### PR TITLE
fix: Ignore ifaddr errors during init

### DIFF
--- a/haconfig/pyoverrides/ifaddr/__init__.py
+++ b/haconfig/pyoverrides/ifaddr/__init__.py
@@ -1,0 +1,9 @@
+# Android (udocker) workaround: If ifaddr fails due to /proc/net permission issues, return an empty list.
+class Adapter:
+    pass
+def get_adapters():
+    try:
+        # Since /proc access is blocked in this environment and always fails, the original function is skipped even if it exists.
+        return []
+    except Exception:
+        return []

--- a/haconfig/pyoverrides/sitecustomize.py
+++ b/haconfig/pyoverrides/sitecustomize.py
@@ -1,0 +1,19 @@
+# In the Android + udocker environment, any /proc paths that trigger a PermissionError are handled
+# as if they do not exist (evaluated as False), thereby allowing Home Assistant to start without interruption.
+
+import pathlib
+
+_orig_exists = pathlib.Path.exists
+
+def _safe_exists(self, *args, **kwargs):
+    try:
+        return _orig_exists(self, *args, **kwargs)
+    except PermissionError:
+        s = str(self)
+        # Typical paths include: ip_forward, net/ 
+        if s.startswith("/proc/sys/net/ipv4/ip_forward") or s.startswith("/proc/net"):
+            return False
+        # In other cases, raise an exception for debugging.
+        raise
+
+pathlib.Path.exists = _safe_exists

--- a/home-assistant-core.sh
+++ b/home-assistant-core.sh
@@ -35,6 +35,7 @@ else
  udocker_run -p "$PORT:8123" \
    -e TZ="$TZ" \
    -v "$STORAGE_PATH:/config" \
+   -e PYTHONPATH="/config/pyoverrides:$PYTHONPATH" \
   "$CONTAINER_NAME" \
   bash -c 'exec python3 -m homeassistant --config /config'
 fi


### PR DESCRIPTION
- override ifaddr and ignore some /proc access to 



<br><br>

Hello,

Thanks to your script, I was able to run Home Assistant on my old smart phone (Samsung S20). I really appreciate it.
However, on my device, the initialization process of HA failed with `ifaddr`-related error, so the provided script alone could not resolve the issue.

To address this, I created the following patch.
The `ifaddr`-realted error during initialize process only limit certain features and do not significantly affect the overall operation of HA.

I hope this helps others who may face similar issues to successfully use HA.

Please review it.

<br><br>

I also encountered issues when trying to run the Matter server.

This patch does not solve those problems.

However, I was able to run [home-assistant-matter-hub](https://github.com/t0bst4r/home-assistant-matter-hub) and successfully expose HA devices to other Matter devices.

Thank you.